### PR TITLE
FIX Issue #8 missing filters molecule_header & molecule_from_yaml

### DIFF
--- a/molecule_digitalocean/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule_digitalocean/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -97,7 +97,7 @@
 
     - name: Dump instance config
       copy:
-        content: "{{ instance_conf | to_json | from_json | molecule_to_yaml | molecule_header }}"
+        content: "{{ instance_conf | to_json | from_json }}"
         dest: "{{ molecule_instance_config }}"
       when: server.changed | bool
 
@@ -108,5 +108,5 @@
         search_regex: SSH
         delay: 10
         timeout: 320
-      with_items: "{{ lookup('file', molecule_instance_config) | molecule_from_yaml }}"
+      with_items: "{{ lookup('file', molecule_instance_config) }}"
 {%- endraw %}

--- a/molecule_digitalocean/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule_digitalocean/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -9,7 +9,7 @@
     - block:
         - name: Populate instance config
           set_fact:
-            instance_conf: "{{ lookup('file', molecule_instance_config) | molecule_from_yaml }}"
+            instance_conf: "{{ lookup('file', molecule_instance_config) }}"
             skip_instances: false
       rescue:
         - name: Populate instance config when file missing
@@ -50,7 +50,7 @@
 
         - name: Dump instance config
           copy:
-            content: "{{ instance_conf | molecule_to_yaml | molecule_header }}"
+            content: "{{ instance_conf }}"
             dest: "{{ molecule_instance_config }}"
           when: server.changed | bool
 


### PR DESCRIPTION
As of molecule v3, ansible molecule filters have been removed.
- ansible-community/molecule#2869
- https://github.com/ansible-community/molecule/releases/tag/3.1.1

FIX
- A better approach would be to modify the digitalocean cookiecutter template to enhance user experience. 
