### PR TITLE
use a valid DigitalOcean droplet size slug within hint message

### DIFF
--- a/molecule_digitalocean/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule_digitalocean/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -30,7 +30,7 @@
           platforms:
             - name: instance
               region: fra1
-              size: 2gb
+              size: s-1vcpu-2gb
               image: ubuntu-20-04-x64
           provisioner:
             name: ansible


### PR DESCRIPTION
Task "Assert that mandatory variables are defined" in create.yml template,
provides an example in case the assertion failed. There it mentioned an invalid
droplet size slug (2gb) this commit replaces with a valid one (s-1vcpu-2gb).