### PR TITLE
Remove ceiling from dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -63,20 +63,20 @@ setup_requires =
 
 # These are required in actual runtime:
 install_requires =
-    molecule >= 3.0a0
-    pyyaml >= 5.1, < 6
+    molecule >= 3.0
+    pyyaml >= 5.1
 
 [options.extras_require]
 test =
-    flake8>=3.6.0, < 4
+    flake8>=3.6.0
 
-    mock>=3.0.5, < 4
-    pytest>=4.6.3, < 5
-    pytest-cov>=2.7.1, < 3
-    pytest-helpers-namespace>=2019.1.8, < 2020
-    pytest-mock>=1.10.4, < 2
-    pytest-verbose-parametrize>=1.7.0, < 2
-    pytest-xdist>=1.29.0, < 2
+    mock>=3.0.5
+    pytest>=4.6.3
+    pytest-cov>=2.7.1
+    pytest-helpers-namespace>=2019.1.8
+    pytest-mock>=1.10.4
+    pytest-verbose-parametrize>=1.7.0
+    pytest-xdist>=1.29.0
     pytest-dependency
 
 [options.entry_points]


### PR DESCRIPTION
This fixes conflict bugs when installing package. Ceiling should
happen only when there is a known/proven incompatibility.
